### PR TITLE
[ ci ] Some simple CI script for building was added

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -1,0 +1,28 @@
+name: Ubuntu
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        idris2-ver:
+          - latest
+          - v0.3.0-625-g699de703
+    container: snazzybucket/idris2:${{ matrix.idris2-ver }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: make
+      - name: Test
+        run: make test INTERACTIVE=''

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+export IDRIS2 ?= idris2
+
+RUNTESTS := build/exec/runtests
+
+.PHONY: all lib clean
+
+all: lib
+
+lib:
+	${IDRIS2} --build experimental.ipkg
+
+clean:
+	${IDRIS2} --clean experimental.ipkg
+	${RM} -r build
+	@
+	@#${MAKE} -C tests clean
+
+.PHONY: test test-lib
+
+test: test-lib
+
+test-lib: lib
+	@echo "No tests yet"
+	@#${MAKE} -C tests only=${only}


### PR DESCRIPTION
For now the lib is build against some given and the latests versions of the compiler. Plus a placeholder for running the tests was left.

For now, CI should fail but this is exactly what happens on my local machine when clean build. When you rebuild from the current state, all typechecks.