### PR TITLE
[ ci ] Make CI green

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         idris2-ver:
           - latest
-          - v0.3.0-625-g699de703
+          - v0.3.0-623-gb457d157
     container: snazzybucket/idris2:${{ matrix.idris2-ver }}
     steps:
       - name: Checkout


### PR DESCRIPTION
An already built compiler version has been used for the docker image. In case you're impatient to wait for tomorrow ;-)